### PR TITLE
Do not double-call prevPage and nextPage callback

### DIFF
--- a/lib/ListIterator.js
+++ b/lib/ListIterator.js
@@ -16,7 +16,6 @@ ListIterator.prototype.nextPage = function(cb) {
 		this.Page++;
 		this.load(cb);
 	}
-	cb(null, this);
 }
 ListIterator.prototype.prevPage = function(cb) {
 	if(this.Page > 0)
@@ -24,7 +23,6 @@ ListIterator.prototype.prevPage = function(cb) {
 		this.Page--;
 		this.load(cb);
 	}
-	cb(null, this);
 }
 ListIterator.prototype.load = function(cb) {
 	var li = this;

--- a/lib/ListIterator.js
+++ b/lib/ListIterator.js
@@ -16,6 +16,8 @@ ListIterator.prototype.nextPage = function(cb) {
 		this.Page++;
 		this.load(cb);
 	}
+  else
+    cb(new Error('No next page.'));
 }
 ListIterator.prototype.prevPage = function(cb) {
 	if(this.Page > 0)
@@ -23,6 +25,8 @@ ListIterator.prototype.prevPage = function(cb) {
 		this.Page--;
 		this.load(cb);
 	}
+  else
+    cb(new Error('No previous page.'));
 }
 ListIterator.prototype.load = function(cb) {
 	var li = this;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "contributors": [ "Jacob Williams <jacob@iakob.com> (http://iakob.com/)" ],
   "name": "twilio-api",
   "description": "Add voice and SMS messaging capabilities to your Node.JS applications with node-twilio-api - a  high-level Twilio helper library to make Twilio API requests, handle incoming requests, and generate TwiML",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/bminer/node-twilio-api/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "Blake Miner <miner.blake@gmail.com> (http://www.blakeminer.com/)",
+  "contributors": [ "Jacob Williams <jacob@iakob.com> (http://iakob.com/)" ],
   "name": "twilio-api",
   "description": "Add voice and SMS messaging capabilities to your Node.JS applications with node-twilio-api - a  high-level Twilio helper library to make Twilio API requests, handle incoming requests, and generate TwiML",
   "version": "0.3.1",


### PR DESCRIPTION
When I use ListIterator.nextPage and pass in a callback, it is passing the callback to the load function, which will call the callback async, and then the nextPage function calls the callback itself, synchronously. This second call will actually contain the Results from the first page, since load has not yet run. prevPage looks like it does the same thing.

I built my code to recursively call nextPage until it is done to download an entire list, however the result is that a 10 page list results in my callback getting called 10 + 9 + 8 + 7... times. Is there another way this is supposed to be used?

This Gist has a sample of how I am trying to use it:
https://gist.github.com/singlow/5008826

Additionally, right now Twilios paging parameters seem to be non-functional for the Accounts list so it is pointless to really test it. Their support team said they are working on that. 

Looks like paging works on non-Accounts lists so I may post an updated gist soon that can be properly tested.
