### PR TITLE
req.protocol does not contain ':'

### DIFF
--- a/lib/Application.js
+++ b/lib/Application.js
@@ -144,7 +144,7 @@ Application.prototype.bridgeCalls = function(c1, c2) {
 Application.prototype.middleware = function() {
 	var app = this;
 	return function(req, res, next) {
-		var protocol = req.protocol || (req.app instanceof tls.Server ? "https:" : "http:");
+		var protocol = (req.protocol || (req.app instanceof tls.Server ? "https" : "http")) + ':';
 		var voiceURL = url.parse(app.VoiceUrl, false, true),
 			voiceStatus = url.parse(app.StatusCallback, false, true),
 			smsURL = url.parse(app.SmsUrl, false, true),


### PR DESCRIPTION
Relying on req.protocol currently gives 404 errors on the middleware calls. This commit fixes that.
